### PR TITLE
Added .835 file types

### DIFF
--- a/edi_835_parser/__init__.py
+++ b/edi_835_parser/__init__.py
@@ -34,7 +34,7 @@ def parse(path: str, debug: bool=False) -> TransactionSets:
 def _find_edi_835_files(path: str) -> List[str]:
 	files = []
 	for file in os.listdir(path):
-		if file.endswith('.txt'):
+		if file.endswith('.txt') or file.endswith('.835'):
 			files.append(file)
 
 	return files


### PR DESCRIPTION
Most 835's seem to end in .txt, but I have them from BC, Harmony, Aetna, cab, Cigna, and a few others, where the extension is .835.