### PR TITLE
Support and test 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  test_job:
+    runs-on: ubuntu-latest
+    name: Run Pytest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - run: pip install -r requirements.txt
+      - run: pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,15 @@ on:
 
 jobs:
   test_job:
-    runs-on: ubuntu-latest
     name: Run Pytest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: ${{ matrix.python-version }}
       - run: pip install -r requirements.txt
       - run: pytest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EDI 835 Parser
 
-[![Python - 3.9.0+](https://img.shields.io/badge/Python-3.9.0%2B-orange)](https://www.python.org/downloads/release/python-390/)
+[![Python - 3.8.0+](https://img.shields.io/badge/Python-3.8.0%2B-orange)](https://www.python.org/downloads/release/python-380/)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/keironstoddart/edi-835-parser)
 [![GitHub license](https://img.shields.io/github/license/Naereen/StrapDown.js.svg)](https://github.com/keironstoddart/edi-835-parser)
 [![Downloads](https://pepy.tech/badge/edi-835-parser)](https://pepy.tech/project/edi-835-parser)
@@ -16,7 +16,7 @@ This package provides a simple-to-use Python interface to EDI 835 Health Care Cl
 **Please consider taking two minutes to [give feedback](https://og5vg099r1x.typeform.com/to/k49iVBI2).**
 
 ### Installation
-Binary installers for the latest released version are at the Python Package Index. Please note that you need to run Python 3.9 or higher to install the edi-835-parser.
+Binary installers for the latest released version are at the Python Package Index. Please note that you need to run Python 3.8 or higher to install the edi-835-parser.
 ```
 pip install edi-835-parser
 ```

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,12 @@ setuptools.setup(
     url="https://github.com/keironstoddart/edi-835-parser",
     packages=setuptools.find_packages(),
     classifiers=[
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
     install_requires=install_requires,
     tests_require=tests_require,
-    python_requires='>=3.9.0',
+    python_requires='>=3.8.0',
 )


### PR DESCRIPTION
As far as I could tell this code doesn't use any 3.9-only features, so this PR edits `setup.py` to support 3.8 (which is still supported until 2024).

This includes the changes from #16, so the diff will be less weird after that is merged. Updates CI to be parameterized by version, which [shows the test pass on both versions](https://github.com/revan/edi-835-parser/actions/runs/3100561312/jobs/5020977949).