### PR TITLE
edi 835 parser cli implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ data.to_csv('~/Desktop/my_edi_file.csv')
 The complete set of `TransactionSets` functionality can be found by inspecting the `TransactionSets` 
 class found at `edi_parser/transaction_set/transaction_sets.py`
 
+### Command Line Interface
+The package also provides a command line interface (CLI) which wraps the parser api.
+
+```shell
+(venv) user@MBP edi-835-parser % edi835 -h  
+usage: EDI 835 Parser [-h] input_location csv_output_file
+
+The EDI 835 Parser CLI writes 835 EDI segments to CSV.
+
+positional arguments:
+  input_location   The path to the input file or directory.
+  csv_output_file  The path to csv file output file.
+
+options:
+  -h, --help       show this help message and exit
+```
+
 ### Tests
 Example EDI 835 files can be found in `tests/test_edi_835/files`. To run the tests use `pytest`.
 ```

--- a/edi_835_parser/cli/main.py
+++ b/edi_835_parser/cli/main.py
@@ -1,0 +1,58 @@
+"""
+main.py
+The EDI 835 Parser Command Line Interface.
+"""
+
+import argparse
+import sys
+from typing import List
+import os
+from edi_835_parser import parse
+
+CLI_DESCRIPTION = """
+The EDI 835 Parser CLI writes 835 EDI segments to CSV.
+"""
+
+
+def _parse_args(cli_args: List[str] = None):
+    """Returns parsed CLI arguments"""
+    parser = argparse.ArgumentParser(
+        prog="EDI 835 Parser",
+        description=CLI_DESCRIPTION,
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+
+    parser.add_argument("input_location",
+                        help="The path to the input file or directory.",
+                        type=str)
+
+    parser.add_argument("csv_output_file",
+                        help="The path to csv file output file.",
+                        type=str)
+    return parser.parse_args(cli_args)
+
+
+def main(cli_args: List[str] = None):
+    """
+    CLI module entrypoint
+    """
+    args = _parse_args(cli_args)
+
+    if not os.path.exists(args.input_location):
+        raise FileNotFoundError(f"input location {args.input_location} does not exist")
+
+    output_directory = os.path.dirname(args.csv_output_file)
+    if not os.path.exists(output_directory):
+        raise FileNotFoundError(f"csv output directory {output_directory} does not exist")
+
+    transaction_sets = parse(args.input_location)
+    data = transaction_sets.to_dataframe()
+    data.to_csv(args.csv_output_file)
+
+
+if __name__ == "__main__":
+    # parsing system arguments and passing them in so that we can:
+    # - bootstrap test cases easily
+    # - print help information if no arguments are provided
+    system_arguments = sys.argv[1:] if sys.argv else []
+    main(system_arguments)

--- a/setup.py
+++ b/setup.py
@@ -29,4 +29,9 @@ setuptools.setup(
     install_requires=install_requires,
     tests_require=tests_require,
     python_requires='>=3.9.0',
+    entry_points={
+        'console_scripts': [
+            'edi835 = edi_835_parser.cli.main:main'
+        ]
+    }
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,34 +1,41 @@
 import os
-import sys
-
 import pytest
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
 import edi_835_parser
 
-current_path = os.path.dirname(os.path.abspath(__file__))
+
+@pytest.fixture
+def base_test_directory():
+	return os.path.dirname(os.path.abspath(__file__))
 
 
 @pytest.fixture
-def blue_cross_nc_sample():
-	path = current_path + '/test_edi_835_files/blue_cross_nc_sample.txt'
+def test_input_directory(base_test_directory):
+	return base_test_directory + '/test_edi_835_files'
+
+
+@pytest.fixture
+def test_output_directory(base_test_directory):
+	return base_test_directory + '/output'
+
+
+@pytest.fixture
+def blue_cross_nc_sample(test_input_directory):
+	path = test_input_directory + '/blue_cross_nc_sample.txt'
 	return edi_835_parser.parse(path)
 
 
 @pytest.fixture
-def emedny_sample():
-	path = current_path + '/test_edi_835_files/emedny_sample.txt'
+def emedny_sample(test_input_directory):
+	path = test_input_directory + '/emedny_sample.txt'
 	return edi_835_parser.parse(path)
 
 
 @pytest.fixture
-def united_healthcare_legacy_sample():
-	path = current_path + '/test_edi_835_files/united_healthcare_legacy_sample.txt'
+def united_healthcare_legacy_sample(test_input_directory):
+	path = test_input_directory + '/united_healthcare_legacy_sample.txt'
 	return edi_835_parser.parse(path)
 
 
 @pytest.fixture
-def all_samples():
-	path = current_path + '/test_edi_835_files'
-	return edi_835_parser.parse(path)
+def all_samples(test_input_directory):
+	return edi_835_parser.parse(test_input_directory)

--- a/tests/test_edi_835_cli.py
+++ b/tests/test_edi_835_cli.py
@@ -1,0 +1,58 @@
+import pandas.testing
+
+from edi_835_parser.cli.main import main
+import pytest
+import pathlib
+from pandas import DataFrame, read_csv
+
+
+def test_cli_validation(tmp_path: pathlib.Path, base_test_directory):
+    """
+    Tests CLI Validations, verifying appropriate exceptions are raised.
+
+    :param tmp_path: pytest fixture which provides a temporary directory for the test case
+    :param test_directory: conftest fixture which provides the path to test edi files
+
+    """
+    args = ['/invalid/directory', tmp_path.as_posix() + '/835.csv']
+    with pytest.raises(FileNotFoundError, match='input location'):
+        main(args)
+
+    args = [base_test_directory, '/invalid/directory/835.csv']
+    with pytest.raises(FileNotFoundError, match='csv output'):
+        main(args)
+
+
+@pytest.mark.parametrize("edi_file_name, csv_file_name",
+                         [
+                             ('blue_cross_nc_sample.txt', 'blue_cross_nc_sample.csv'),
+                             ('emedny_sample.txt', 'emedny_sample.csv'),
+                             ('united_healthcare_legacy_sample.txt', 'united_healthcare_legacy_sample.csv')
+                         ])
+def test_cli(tmp_path: pathlib.Path,
+             test_input_directory: str,
+             test_output_directory: str,
+             edi_file_name: str,
+             csv_file_name: str):
+    """
+    Tests the edi-835 parser using the cli "main" function.
+
+    :param tmp_path: Pytest fixture used to provide "temp" directories with test cases.
+    :param test_input_directory: The test_input_directory fixture defined in conftest.
+    :param test_output_directory: The test_output_directory fixture defined in conftest.
+    :param edi_file_name: The input edi file name used in the test case.
+    :param csv_file_name: The output csv file name used to compare results for the test case.
+    """
+    # run main cli function
+    actual_file = f'{tmp_path.as_posix()}/{csv_file_name}'
+    args = [
+        f'{test_input_directory}/{edi_file_name}',
+        actual_file
+    ]
+    main(args)
+
+    expected_file = f'{test_output_directory}/{csv_file_name}'
+    expected_df: DataFrame = read_csv(expected_file, index_col=0)
+
+    actual_df: DataFrame = read_csv(actual_file, index_col=0)
+    pandas.testing.assert_frame_equal(expected_df, actual_df)

--- a/tests/test_edi_835_parser.py
+++ b/tests/test_edi_835_parser.py
@@ -1,5 +1,3 @@
-from tests.conftest import current_path
-
 def test_claim_count(
 		blue_cross_nc_sample,
 		emedny_sample,
@@ -24,6 +22,7 @@ def test_patient_count(
 	assert all_samples.count_patients() == 6
 
 def test_to_dataframe(
+		test_output_directory,
 		blue_cross_nc_sample,
 		emedny_sample,
 		united_healthcare_legacy_sample,
@@ -34,25 +33,25 @@ def test_to_dataframe(
 
 	assert payment == blue_cross_nc_data['paid_amount'].sum()
 
-	blue_cross_nc_data.to_csv(f'{current_path}/output/blue_cross_nc_sample.csv')
+	blue_cross_nc_data.to_csv(f'{test_output_directory}/blue_cross_nc_sample.csv')
 
 	payment = emedny_sample.sum_payments()
 	emedny_data = emedny_sample.to_dataframe()
 
 	assert payment == emedny_data['paid_amount'].sum()
 
-	emedny_data.to_csv(f'{current_path}/output/emedny_sample.csv')
+	emedny_data.to_csv(f'{test_output_directory}/emedny_sample.csv')
 
 	payment = united_healthcare_legacy_sample.sum_payments()
 	united_healthcare_legacy_ = united_healthcare_legacy_sample.to_dataframe()
 
 	assert payment == united_healthcare_legacy_['paid_amount'].sum()
 
-	united_healthcare_legacy_.to_csv(f'{current_path}/output/united_healthcare_legacy_sample.csv')
+	united_healthcare_legacy_.to_csv(f'{test_output_directory}/united_healthcare_legacy_sample.csv')
 
 	payment = all_samples.sum_payments()
 	all_data = all_samples.to_dataframe()
 
 	assert payment == all_data['paid_amount'].sum().round(2)
 
-	all_data.to_csv(f'{current_path}/output/all_samples.csv')
+	all_data.to_csv(f'{test_output_directory}/all_samples.csv')


### PR DESCRIPTION
This PR implements a simple argparse based CLI to support writing input EDI files to CSV. 

Changes in this PR include:

- consolidating conftest fixtures pertaining to test and output directories
- added cli package and cli.main module
- updated setup.py to support the new cli "entrypoint"
- added test cases

closes #18 

